### PR TITLE
Changed version dependency from builder '>= 3.0.0' to '>= 2.1.2'

### DIFF
--- a/pswincom.gemspec
+++ b/pswincom.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'pswincom'
-  s.version         = '0.1.1'
+  s.version         = '0.1.2'
   s.authors         = ['PSWinCom AS']
   s.email           = ['support@pswin.com']
   s.homepage        = 'http://github.com/tormaroe/pswincomgem'
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.summary         = "API for the PSWinCom SMS Gateway."
   s.description     = "An easy to use API for the PSWinCom SMS Gateway, allowing you to send SMS messages."
 
-  s.add_dependency('builder', '>= 3.0.0')
+  s.add_dependency('builder', '>= 2.1.2')
 
   s.files           = Dir.glob("{bin,lib}/**/*") + %w(LICENSE README.md)
   s.require_path    = 'lib'


### PR DESCRIPTION
I can see no reason for why it should require the newest version. This also prevents problems with gems like activemodel that currently requires builder '~> 2.1.2'.
