### PR TITLE
Ensure ISO-8859-1 when sending to gateway

### DIFF
--- a/lib/pswincom/httpsender.rb
+++ b/lib/pswincom/httpsender.rb
@@ -13,8 +13,8 @@ module PSWinCom
     def send request
       url = URI.parse @host
       post = Net::HTTP::Post.new(url.path)
-      post.body = request.xml
-      post.content_type = 'text/xml'
+      post.body = request.xml.encode("ISO-8859-1")
+      post.content_type = 'text/xml charset=ISO-8859-1'
       Net::HTTP.start(url.host, url.port) {|http| http.request(post)}
     end
   end

--- a/spec/httpsender_spec.rb
+++ b/spec/httpsender_spec.rb
@@ -25,7 +25,7 @@ module PSWinCom
       it "sends XML with correct content type" do
         post = HttpSender.new.send(XmlMock.new("<xml>foo</xml>"))
         post.body.should == "<xml>foo</xml>"
-        post.content_type.should == 'text/xml'
+        post.content_type.should == 'text/xml charset=ISO-8859-1'
       end
     end
   end


### PR DESCRIPTION
ISO-8859-1 is expected for the HTTP API docs, so I'm assuming the same holds for the XML API.

For the XML API to accept unicode characters in messages the OP element must be set to 9, but the gem doesn't set this element when posting.

Noticed similar changes being made to the python library a while ago: https://github.com/PSWinCom/pswinpy/commit/6d1e6dd28f50acc5b4a36b6bc73dcb4bebd0374f
